### PR TITLE
API paths should be relative to the base API URL

### DIFF
--- a/prometheus_pandas/query.py
+++ b/prometheus_pandas/query.py
@@ -23,7 +23,7 @@ class Prometheus:
         params.update({'time': time} if time is not None else {})
         params.update({'timeout': timeout.total_seconds()} if timeout is not None else {})
 
-        return to_pandas(self._do_query('/api/v1/query', params))
+        return to_pandas(self._do_query('api/v1/query', params))
 
     def query_range(self, query, start, end, step, timeout=None):
         """
@@ -39,7 +39,7 @@ class Prometheus:
         params = {'query': query, 'start': start, 'end': end, 'step': step}
         params.update({'timeout': timeout} if timeout is not None else {})
 
-        return to_pandas(self._do_query('/api/v1/query_range', params))
+        return to_pandas(self._do_query('api/v1/query_range', params))
 
     def _do_query(self, path, params):
         resp = requests.get(urljoin(self.api_url, path), params=params)


### PR DESCRIPTION
Hi, thank you for this useful library. I found a small bug in the way API URLs are constructed. When the API base URL contains a subpath (`https://example.com/hello/` instead of just `https://example.com/`) then the API endpoint path (`/api/v1/query`) replaces that completely:

```
>>> from urllib.parse import urljoin
>>> urljoin('https://example.com', '/api')
'https://example.com/api'
>>> urljoin('https://example.com/hello/', '/api')
'https://example.com/api'  # <--- not what was intended
```

The fix is easy: don't use an 'absolute' path:

```
>>> urljoin('https://example.com', 'api')
'https://example.com/api'
>>> urljoin('https://example.com/hello/', 'api')
'https://example.com/hello/api'
```