### PR TITLE
Allow customizing of Requests session

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ dtype: float64
 2020-10-05 06:00:00         0.018222       0.035111
 ```
 
+Customizing the HTTP request:
+
+```python
+>>> import requests
+>>> from prometheus_pandas import query
+>>>
+>>> http = requests.Session()
+>>> http.cert = '/path/client.cert'
+>>> http.verify = '/path/to/certfile'
+>>>
+>>> p = query.Prometheus('http://localhost:9090', http)
+>>> print(p.query('node_cpu_seconds_total{mode="system"}', '2020-10-05T00:00:00Z'))
+node_cpu_seconds_total{cpu="0",instance="localhost:9100",job="node",mode="system"}    3954.92
+dtype: float64
+```
+
 ## Installation
 
 Latest release via [`pip`](https://pip.pypa.io):

--- a/prometheus_pandas/query.py
+++ b/prometheus_pandas/query.py
@@ -16,13 +16,14 @@ String = str
 
 
 class Prometheus:
-    def __init__(self, api_url: str):
+    def __init__(self, api_url: str, http: Optional[requests.Session] = None):
         """
         Create Prometheus client.
 
         :param api_url: URL of Prometheus server.
+        :param http: Requests Session to use for requests. Optional.
         """
-        self.http = requests.Session()
+        self.http = http or requests.Session()
         self.api_url = api_url
 
     def __enter__(self):


### PR DESCRIPTION
This can be used for authentication or customization of certificates.

```python
import requests
from prometheus_pandas import query

http = requests.Session()
http.cert = '/path/client.cert'
http.verify = '/path/to/certfile'

p = query.Prometheus('http://127.0.0.1:9090', http)
print(p.query('node_cpu_seconds_total{mode="system"}', '2020-10-05T00:00:00Z'))
```