### PR TITLE
Document that api_url must have a trailing slash

### DIFF
--- a/prometheus_pandas/query.py
+++ b/prometheus_pandas/query.py
@@ -20,7 +20,7 @@ class Prometheus:
         """
         Create Prometheus client.
 
-        :param api_url: URL of Prometheus server.
+        :param api_url: URL of Prometheus server. Must end with a trailing slash.
         :param http: Requests Session to use for requests. Optional.
         """
         self.http = http or requests.Session()


### PR DESCRIPTION
Thank you for this wonderful library!

`api_url` needs to have a trailing slash, otherwise the last part of the URL is replaced with `api` by the url joining code later on, resulting in 404 errors that are slightly odd to debug.